### PR TITLE
Allow upper case scientific notation

### DIFF
--- a/VMFInstanceInserter/VMFValue.cs
+++ b/VMFInstanceInserter/VMFValue.cs
@@ -112,7 +112,7 @@ namespace VMFInstanceInserter
 
     public class VMFNumberValue : VMFValue
     {
-        public static readonly String Pattern = "-?[0-9]+(\\.[0-9]+)?(e-?[0-9]+)?";
+        public static readonly String Pattern = "-?[0-9]+(\\.[0-9]+)?([eE]-?[0-9]+)?";
         public static readonly int Order = 5;
 
         private double _value;


### PR DESCRIPTION
Back again with another annoying pull request! I have no other pending projects, so hopefully you won't have to hear from me again for a while, but as I finished up the one I had been working on ("Exempli Gratia", map number two in [RavenholmVille](http://www.planetphillip.com/posts/ravenholmville-half-life-2-ep2/), source included) I came across some entities and textures that were rotated strangely after a couple levels of nested instances. Turns out those oddball items were using numbers represented as scientific notation using a capital E, which the VMFNumberValue pattern didn't account for.

If there's another way you'd prefer to handle this, go right ahead, but this worked for my purposes and seemed easier than throwing calls to ToLower everywhere.
