### PR TITLE
Rename .temp.lin to .lin (and deletes old .lin files)

### DIFF
--- a/VMFInstanceInserter/Program.cs
+++ b/VMFInstanceInserter/Program.cs
@@ -69,14 +69,14 @@ namespace VMFInstanceInserter
                 String lin = rootName + ".lin";
                 String tempLin = rootName + ".temp.lin";
 
+                if (File.Exists(lin))
+                {
+                    Console.WriteLine(del + lin);
+                    File.Delete(lin);
+                }
+
                 if (File.Exists(tempLin))
                 {
-                    if (File.Exists(lin))
-                    {
-                        Console.WriteLine(del + lin);
-                        File.Delete(lin);
-                    }
-
                     Console.WriteLine(renaming, tempLin, lin);
                     File.Move(tempLin, lin);
                 }


### PR DESCRIPTION
This allows Hammer to detect the correct point file instead of having to browse. It's just a convenience.
