### PR TITLE
Fix info_overlay resolution

### DIFF
--- a/VMFInstanceInserter/VMFStructure.cs
+++ b/VMFInstanceInserter/VMFStructure.cs
@@ -126,7 +126,7 @@ namespace VMFInstanceInserter
         private static readonly Regex _sIncludeRegex = new Regex("^@include \"[^\"]+\"");
         private static readonly Regex _sClassTypeRegex = new Regex("^@[A-Z]([A-Za-z])*Class( |=)");
         private static readonly Regex _sBaseDefRegex = new Regex("base\\(\\s*[A-Za-z0-9_]+(\\s*,\\s*[A-Za-z0-9_]+)*\\s*\\)");
-        private static readonly Regex _sParamDefRegex = new Regex("^[a-zA-Z0-9_]+\\s*\\(\\s*[A-Za-z0-9_]+\\s*\\)\\s*:.*$");
+        private static readonly Regex _sParamDefRegex = new Regex("^[a-zA-Z0-9_]+\\s*\\(\\s*[A-Za-z0-9_]+\\s*\\)(\\s*readonly\\s*|\\s*):.*$");
         public static void ParseFGD(String path)
         {
             Console.WriteLine("Loading {0}", Path.GetFileName(path));
@@ -212,6 +212,13 @@ namespace VMFInstanceInserter
                             // Temporary hack to fix mistake on valve's part
                             if (curName == "func_useableladder" && (name == "point0" || name == "point1")) {
                                 type = TransformType.Position;
+                            } else if (curName == "info_overlay") {
+                                if (name == "BasisOrigin")
+                                    type = TransformType.Position;
+                                else if (name == "BasisNormal" || name == "BasisU" || name == "BasisV")
+                                    type = TransformType.Offset;
+                                else
+                                    type = TransformType.None;
                             } else {
                                 type = TransformType.Offset;
                             }


### PR DESCRIPTION
I picked up a little linear algebra a couple months ago, and between that knowledge and the motivation of a new project, I've managed to work up what I believe is a solution to issue #14, which I posted back in April. 

There's the FGD parsing side of things, where the parameter definition regex didn't pick up "readonly" properties, and then there's a few special case needs that info_overlay has. The different capitalization Valve uses in base.fgd, where some things are "vector" and others "Vector", doesn't seem to consistently indicate a difference, and only through trial and error did the answer make itself clear.

I've got a test map I used to check my results, rotating a func_instance all over the place and nesting it two levels, and I can commit it if you want, but I didn't want to clutter up the repo with these things any more than I have already (I didn't mean to be pushy with those vecline tests way back when, I just wanted to be thorough).

Let me know if you want any changes and I can get right on them!
