### PR TITLE
Fix processing of displacements

### DIFF
--- a/VMFInstanceInserter/VMFStructure.cs
+++ b/VMFInstanceInserter/VMFStructure.cs
@@ -80,6 +80,10 @@ namespace VMFInstanceInserter
             {
                 { "row[0-9]+", TransformType.Offset }
             } },
+            { VMFStructureType.Offsets, new Dictionary<String, TransformType>
+            {
+                { "row[0-9]+", TransformType.Offset }
+            } },
             { VMFStructureType.Offset_Normals, new Dictionary<String, TransformType>
             {
                 { "row[0-9]+", TransformType.Offset }


### PR DESCRIPTION
I'm back to be a nuisance again! This time I've got an addition to your displacement code. I just finished up "Drip Leg", my submission for PlanetPhillip's HorrorVille challenge, and had been having trouble with my displacements behaving strangely. Walls bulging in when they should be curving out, for example. I had the instance yawed 180 degrees, but spinning it back around to 0 cleared up the problem, so I figured something wasn't being accounted for, and it looks like it's the dispinfo "offsets" block.

I figured out the change with a few days left on the deadline; the subsequent weekend of furious mapping has me convinced my extremely sophisticated copy-and-paste is working, but please do review it and enlighten me if I'm missing anything.
