### PR TITLE
Fix duplicate angle in dictionary error

### DIFF
--- a/VMFInstanceInserter/VMFStructure.cs
+++ b/VMFInstanceInserter/VMFStructure.cs
@@ -176,7 +176,7 @@ namespace VMFInstanceInserter
 
                     // Don't rotate angles for brush entities
                     if (match.Groups["classType"].Value.Equals("SolidClass", StringComparison.InvariantCultureIgnoreCase)) {
-                        curDict.Add("angles", TransformType.None);
+                        curDict["angles"] = TransformType.None;
                     }
 
                     var basesMatch = _sBaseDefRegex.Match(line);


### PR DESCRIPTION
The commit https://github.com/Metapyziks/VMFInstanceInserter/commit/9487796dbda67c12e4c8e6508b980125b82a1db2#diff-b6cd5396d3ebfa4934fa608dc1f60ea4R179 introduced the following error:

```c#
Unhandled Exception: System.ArgumentException: An item with the same key has already been added.
   at System.ThrowHelper.ThrowArgumentException(ExceptionResource resource)
   at System.Collections.Generic.Dictionary`2.Insert(TKey key, TValue value, Boolean add)
   at VMFInstanceInserter.VMFStructure.ParseFGD(String path)
   at VMFInstanceInserter.VMFStructure.ParseFGD(String path)
   at VMFInstanceInserter.Program.Main(String[] args)
```

I have not tested this change much, but it should fix it.